### PR TITLE
Register a panic handler that logs to console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "rand",
  "ristretto255-dlog",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -877,6 +878,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/unified/Cargo.toml
+++ b/unified/Cargo.toml
@@ -25,6 +25,7 @@ curve25519-dalek = { version = "4", default-features = false }
 # WASM bindings
 wasm-bindgen = "0.2.99"
 js-sys = "0.3.77"
+web-sys = { version = "0.3", features = ["console"] }
 getrandom = { version = "0.2", features = ["js"] }
 
 # Range proofs (v5.0.0 uses curve25519-dalek v4, compatible with pollard-kangaroo)

--- a/unified/src/lib.rs
+++ b/unified/src/lib.rs
@@ -17,6 +17,17 @@
 //! - `bsgs`: Standard Baby-Step Giant-Step
 //! - `bl12`: Bernstein-Lange 2012 (smallest table, slower)
 
-// Placeholder - full implementation will be added in subsequent commits
+use wasm_bindgen::prelude::*;
+
+/// Installs a panic hook that forwards Rust panic messages to `console.error`.
+/// Called automatically on WASM init. Without this, panics surface as an
+/// opaque `RuntimeError: unreachable` with no message.
+#[wasm_bindgen(start)]
+pub fn init() {
+    std::panic::set_hook(Box::new(|info| {
+        web_sys::console::error_1(&format!("{info}").into());
+    }));
+}
+
 pub mod discrete_log;
 pub mod range_proof;


### PR DESCRIPTION
## Test Plan

**Repro script**: Any WASM operation that triggers a Rust panic (e.g. `batch_range_proof` on Node.js ESM, where `getrandom` can't find a crypto source).

### Before (v0.0.3, no panic hook)

```
CRASHED: unreachable
RuntimeError: unreachable
    at ...aptos_confidential_asset_wasm_bg.wasm:wasm-function[169]:0x305a4
    at ...aptos_confidential_asset_wasm_bg.wasm:wasm-function[240]:0x34971
    at ...aptos_confidential_asset_wasm_bg.wasm:wasm-function[261]:0x37dcb
    at ...aptos_confidential_asset_wasm_bg.wasm:wasm-function[248]:0x36af8
    at batch_range_proof (aptos_confidential_asset_wasm-esm.js:209:22)
```

No indication of what went wrong — just opaque WASM function offsets.

### After (this PR, with panic hook)

```
panicked at /Users/dport/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rand-0.8.5/src/rngs/thread.rs:72:17:
could not initialize thread_rng: Node.js ES modules are not directly supported, see https://docs.rs/getrandom#nodejs-es-module-support
CRASHED: unreachable
RuntimeError: unreachable
    at wasm://wasm/0030c726:wasm-function[175]:0x3240f
    ...
    at batch_range_proof (aptos_confidential_asset_wasm-esm.js:130:22)
```

The panic message now prints to `console.error` **before** the `unreachable` trap, showing the exact file, line, and error message from the Rust panic. In this case it immediately tells us the root cause is `getrandom` failing in Node.js ESM mode.

### How to reproduce

```bash
# Prerequisites: a running localnet
aptos node run-localnet -f -y

# In aptos-indexer-processors-v2/scripts/test-confidential-asset:
npx tsx repro-wasm-crash.ts
```

The script registers a confidential balance, deposits funds, rolls over, then attempts `normalizeBalance` (which calls `batch_range_proof`). With the old WASM you get bare `unreachable`; with this PR's WASM you get the full panic message on `console.error`.