### PR TITLE
fix release tag push and append FFI to Changesets Release

### DIFF
--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -187,6 +187,27 @@ jobs:
           echo "--- SHA256SUMS ---"
           cat SHA256SUMS
 
+      # changeset publish may push the tag before this workflow finishes starting; matrix
+      # builds take several minutes. Poll here so append_body never races an in-flight Release.
+      - name: Wait for Changesets GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.rel.outputs.tag }}"
+          REPO="${{ github.repository }}"
+          for attempt in $(seq 1 36); do
+            if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+              echo "GitHub Release $TAG is ready (attempt ${attempt}/36)."
+              exit 0
+            fi
+            echo "Waiting for Changesets GitHub Release ${TAG}... (${attempt}/36)"
+            sleep 10
+          done
+          echo "error: GitHub Release ${TAG} not found after 6 minutes — cannot append FFI assets." >&2
+          exit 1
+
       - name: Write FFI appendix for existing Release
         run: |
           set -euo pipefail

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -1,6 +1,7 @@
 # Native staticlib + header — invoked by `release.yml` after Changesets publish (workflow_call).
 # Appends FFI notes and archives to the existing Changesets GitHub Release. Manual
-# workflow_dispatch remains for backfills / dry-runs. Tag push does not trigger this workflow.
+# workflow_dispatch is for backfills only: a Release with changelog must already exist for vX.Y.Z.
+# Tag push does not trigger this workflow. Re-running append_body duplicates the Native FFI section.
 name: Release native FFI binaries
 
 on:
@@ -154,7 +155,6 @@ jobs:
           echo "draft=${{ inputs.draft }}" >> "$GITHUB_OUTPUT"
 
       - name: Verify root package.json matches release version
-        if: github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -1,5 +1,6 @@
-# Native staticlib + header — triggered by semver git tags (see `release.yml`, which pushes `v*`
-# after a successful npm publish). Optional `workflow_dispatch` for dry-runs / forks.
+# Native staticlib + header — runs after `release.yml` publishes npm and pushes `v*`.
+# Appends FFI download notes and binary archives to the existing Changesets GitHub Release
+# (same tag). Optional `workflow_dispatch` for dry-runs / forks.
 name: Release native FFI binaries
 
 on:
@@ -129,7 +130,7 @@ jobs:
           path: dist/aptos_confidential_asset_ffi-${{ matrix.target }}.zip
 
   aggregate-and-release:
-    name: Aggregate checksums + GitHub Release
+    name: Aggregate checksums + attach FFI to Release
     needs: build-ffi-matrix
     runs-on: ubuntu-latest
     steps:
@@ -186,21 +187,33 @@ jobs:
           echo "--- SHA256SUMS ---"
           cat SHA256SUMS
 
-      - name: Create GitHub Release with assets
+      - name: Write FFI appendix for existing Release
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.rel.outputs.tag }}"
+          VER="${{ steps.rel.outputs.ver }}"
+          PKG="@aptos-labs/confidential-asset-bindings"
+          REPO="${{ github.repository }}"
+          {
+            echo "---"
+            echo ""
+            echo "### Native FFI (\`aptos_confidential_asset_ffi\`)"
+            echo ""
+            echo "Prebuilt C ABI static libraries for Go / C++ / Zig (attached below). Each archive includes \`aptos_confidential_asset.h\` and the static library for one target triple."
+            echo ""
+            echo "- **npm:** [\`${PKG}@${VER}\`](https://www.npmjs.com/package/${PKG}/v/${VER})"
+            echo "- **Checksums:** \`SHA256SUMS\`"
+            echo "- **Docs:** [docs/bindings.md](https://github.com/${REPO}/blob/${TAG}/docs/bindings.md)"
+          } > ffi-release-append.md
+          cat ffi-release-append.md
+
+      - name: Attach FFI binaries to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.rel.outputs.tag }}
-          name: aptos_confidential_asset_ffi ${{ steps.rel.outputs.tag }}
           draft: ${{ steps.rel.outputs.draft == 'true' }}
-          generate_release_notes: true
-          body: |
-            Native FFI static libraries for `aptos_confidential_asset_ffi` (C ABI).
-
-            **Git tag:** `${{ steps.rel.outputs.tag }}` — align with npm **`@aptos-labs/confidential-asset-bindings@${{ steps.rel.outputs.ver }}`** when shipping both.
-
-            Includes `SHA256SUMS` for all attached archives. Header: `aptos_confidential_asset.h` inside each archive.
-
-            See [docs/bindings.md](https://github.com/${{ github.repository }}/blob/main/docs/bindings.md) for consumption (Go / C++).
+          append_body: true
+          body_path: ffi-release-append.md
           files: |
             release-files/*.tar.gz
             release-files/*.zip

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -1,17 +1,24 @@
-# Native staticlib + header — runs after `release.yml` publishes npm and pushes `v*`.
-# Appends FFI download notes and binary archives to the existing Changesets GitHub Release
-# (same tag). Optional `workflow_dispatch` for dry-runs / forks.
+# Native staticlib + header — invoked by `release.yml` after Changesets publish (workflow_call).
+# Appends FFI notes and archives to the existing Changesets GitHub Release. Manual
+# workflow_dispatch remains for backfills / dry-runs. Tag push does not trigger this workflow.
 name: Release native FFI binaries
 
 on:
-  push:
-    tags:
-      # Semver tags: v1.2.3, v1.2.3-rc.1, … (align with npm @aptos-labs/confidential-asset-bindings)
-      - "v*.*.*"
+  workflow_call:
+    inputs:
+      version:
+        description: "Semver X.Y.Z without leading v (must match package.json on the release commit)"
+        required: true
+        type: string
+      draft:
+        description: "Create or update the GitHub Release as draft"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
-        description: "Semver X.Y.Z without leading v (manual fallback; npm publish auto-pushes vX.Y.Z via release.yml)"
+        description: "Semver X.Y.Z without leading v (manual backfill / dry-run)"
         required: true
         default: "1.0.0"
       draft:
@@ -20,7 +27,7 @@ on:
         default: true
 
 concurrency:
-  group: ffi-release-${{ github.repository }}-${{ github.ref }}
+  group: ffi-release-${{ github.repository }}-${{ inputs.version }}
   cancel-in-progress: false
 
 permissions:
@@ -141,21 +148,13 @@ jobs:
         id: rel
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VER="${{ inputs.version }}"
-            echo "tag=v${VER}" >> "$GITHUB_OUTPUT"
-            echo "ver=${VER}" >> "$GITHUB_OUTPUT"
-            echo "draft=${{ inputs.draft }}" >> "$GITHUB_OUTPUT"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-            VER="${TAG#v}"
-            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-            echo "ver=${VER}" >> "$GITHUB_OUTPUT"
-            echo "draft=false" >> "$GITHUB_OUTPUT"
-          fi
+          VER="${{ inputs.version }}"
+          echo "tag=v${VER}" >> "$GITHUB_OUTPUT"
+          echo "ver=${VER}" >> "$GITHUB_OUTPUT"
+          echo "draft=${{ inputs.draft }}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify root package.json matches release tag
-        if: github.event_name == 'push'
+      - name: Verify root package.json matches release version
+        if: github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -euo pipefail
@@ -187,10 +186,10 @@ jobs:
           echo "--- SHA256SUMS ---"
           cat SHA256SUMS
 
-      # changeset publish may push the tag before this workflow finishes starting; matrix
-      # builds take several minutes. Poll here so append_body never races an in-flight Release.
+      # workflow_call runs only after Changesets publish in release.yml; manual dispatch may
+      # run without a prior Release — poll briefly before append_body.
       - name: Wait for Changesets GitHub Release
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -202,7 +201,7 @@ jobs:
               echo "GitHub Release $TAG is ready (attempt ${attempt}/36)."
               exit 0
             fi
-            echo "Waiting for Changesets GitHub Release ${TAG}... (${attempt}/36)"
+            echo "Waiting for GitHub Release ${TAG}... (${attempt}/36)"
             sleep 10
           done
           echo "error: GitHub Release ${TAG} not found after 6 minutes — cannot append FFI assets." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
           publish: npm run release
           commit: "chore: version packages"
           title: "chore: version packages"
-          # Changesets creates the GitHub Release (CHANGELOG body). Tag push then runs
-          # bindings-release.yml to attach native staticlib archives to that same release.
+          # Changesets creates the GitHub Release (CHANGELOG body) during publish. Pushing the
+          # tag below triggers bindings-release.yml (separate workflow) to append FFI assets.
         env:
           GITHUB_TOKEN: ${{ steps.aptos-labs-bot-auth.outputs.token }}
 
-      # Single release flow: after npm publish, push semver tag so "Release native FFI binaries"
-      # (bindings-release.yml) builds and uploads prebuilt static libraries for the same version.
+      # After publish: ensure vX.Y.Z exists on origin (changeset publish may have pushed it
+      # already). Tag push starts bindings-release.yml — not an in-job call; see that workflow.
       - name: Push semver tag for native FFI release
         if: steps.changesets.outputs.published == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: macos-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      version: ${{ steps.release_meta.outputs.version }}
     permissions:
       id-token: write
       contents: write
@@ -51,14 +54,17 @@ jobs:
           publish: npm run release
           commit: "chore: version packages"
           title: "chore: version packages"
-          # Changesets creates the GitHub Release (CHANGELOG body) during publish. Pushing the
-          # tag below triggers bindings-release.yml (separate workflow) to append FFI assets.
+          # Changesets creates the GitHub Release (CHANGELOG body) during publish.
         env:
           GITHUB_TOKEN: ${{ steps.aptos-labs-bot-auth.outputs.token }}
 
-      # After publish: ensure vX.Y.Z exists on origin (changeset publish may have pushed it
-      # already). Tag push starts bindings-release.yml — not an in-job call; see that workflow.
-      - name: Push semver tag for native FFI release
+      - name: Export published package version
+        id: release_meta
+        if: steps.changesets.outputs.published == 'true'
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # Git tag for consumers (Go module pin, release page). FFI attach is workflow_call below.
+      - name: Push semver git tag
         if: steps.changesets.outputs.published == 'true'
         run: |
           set -euo pipefail
@@ -80,3 +86,13 @@ jobs:
             git tag -a "${TAG}" -m "chore(release): ${TAG} (npm + native FFI)"
             git push origin "refs/tags/${TAG}"
           fi
+
+  native-ffi-release:
+    name: Native FFI release
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    uses: ./.github/workflows/bindings-release.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+      draft: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Export published package version
         id: release_meta
         if: steps.changesets.outputs.published == 'true'
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
 
       # Git tag for consumers (Go module pin, release page). FFI attach is workflow_call below.
       - name: Push semver git tag
@@ -91,6 +91,8 @@ jobs:
     name: Native FFI release
     needs: release
     if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/bindings-release.yml
     with:
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,16 @@ jobs:
           git pull --ff-only origin "${BRANCH}"
           VERSION="$(node -p "require('./package.json').version")"
           TAG="v${VERSION}"
-          if git rev-parse "${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists locally; skipping."
-            exit 0
-          fi
           if git ls-remote --tags origin "refs/tags/${TAG}" | grep -qF "refs/tags/${TAG}"; then
             echo "Tag ${TAG} already exists on origin; skipping."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "chore(release): ${TAG} (npm + native FFI)"
-          git push origin "refs/tags/${TAG}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} exists locally (e.g. from changeset publish); pushing to origin."
+            git push origin "refs/tags/${TAG}"
+          else
+            git tag -a "${TAG}" -m "chore(release): ${TAG} (npm + native FFI)"
+            git push origin "refs/tags/${TAG}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
           publish: npm run release
           commit: "chore: version packages"
           title: "chore: version packages"
-          # Native FFI workflow creates the GitHub Release for `v*` (staticlibs + SHA256SUMS).
-          createGithubReleases: false
+          # Changesets creates the GitHub Release (CHANGELOG body). Tag push then runs
+          # bindings-release.yml to attach native staticlib archives to that same release.
         env:
           GITHUB_TOKEN: ${{ steps.aptos-labs-bot-auth.outputs.token }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ GitHub Actions run in the repository where they execute. On a fork, configure **
 
 If Changesets cannot open PRs, add secret **`CHANGESETS_GITHUB_TOKEN`** (PAT with `repo`, or fine-grained Contents + Pull requests write). The Release workflow uses `secrets.CHANGESETS_GITHUB_TOKEN || github.token`.
 
-To **ship native FFI artifacts for Go** after an npm release: no manual step is required — **`release.yml`** calls **Release native FFI binaries** (`bindings-release.yml` via `workflow_call`) after Changesets publish, then pushes **`vX.Y.Z`**. See [`docs/contributors/releasing.md`](docs/contributors/releasing.md).
+To **ship native FFI artifacts for Go** after an npm release: no manual step is required — one **`release.yml`** run publishes via Changesets (npm + GitHub Release changelog), pushes **`vX.Y.Z`** for git/Go pins, then calls **Release native FFI binaries** (`bindings-release.yml` via `workflow_call`) to append staticlibs. Tag push does not start the FFI workflow. See [`docs/contributors/releasing.md`](docs/contributors/releasing.md).
 
 ## Coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ GitHub Actions run in the repository where they execute. On a fork, configure **
 
 If Changesets cannot open PRs, add secret **`CHANGESETS_GITHUB_TOKEN`** (PAT with `repo`, or fine-grained Contents + Pull requests write). The Release workflow uses `secrets.CHANGESETS_GITHUB_TOKEN || github.token`.
 
-To **ship native FFI artifacts for Go** after an npm release: no manual tag is required — **`release.yml`** pushes **`vX.Y.Z`** after a successful publish, which runs **Release native FFI binaries** (`bindings-release.yml`). See [`docs/contributors/releasing.md`](docs/contributors/releasing.md).
+To **ship native FFI artifacts for Go** after an npm release: no manual step is required — **`release.yml`** calls **Release native FFI binaries** (`bindings-release.yml` via `workflow_call`) after Changesets publish, then pushes **`vX.Y.Z`**. See [`docs/contributors/releasing.md`](docs/contributors/releasing.md).
 
 ## Coding standards
 

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -73,9 +73,9 @@ Repository admins should mark **Bindings (FFI + Go)** and **Android JNI (FFI arm
 
 ## Releases (FFI binaries)
 
-**One release path:** merging **Version Packages** triggers `npm run release` on `main`; when publish succeeds, **`release.yml`** pushes **`vX.Y.Z`**, which runs **Release native FFI binaries** and creates the GitHub Release with prebuilt `libaptos_confidential_asset_ffi` archives and **`SHA256SUMS`**. Changelog for npm remains in `CHANGELOG.md`; the GitHub Release is the native-FFI asset bundle.
+**Normal path:** merging **Version Packages** runs **`release.yml`** on `main`: Changesets publishes to npm and creates the GitHub Release (changelog in the Release body, also in `CHANGELOG.md`); the same workflow run calls **`bindings-release.yml`** via **`workflow_call`** to append prebuilt `libaptos_confidential_asset_ffi` archives and **`SHA256SUMS`**. Git tag **`vX.Y.Z`** is pushed for version pins — tag push does **not** start the FFI workflow.
 
-Use **Actions → Release native FFI binaries** (`workflow_dispatch`) only as a fallback (e.g. draft rebuild) — see [releasing.md](contributors/releasing.md).
+**Manual fallback:** **Actions → Release native FFI binaries** (`workflow_dispatch`) only when a Release for **`vX.Y.Z`** already exists — see [releasing.md](contributors/releasing.md).
 
 ### Prebuilt triples (GitHub Release matrix)
 

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -6,7 +6,7 @@ Experimental **Go** bindings over the same cryptographic core as the npm package
 
 - **npm / JS** remains the primary semver surface (`package.json`).
 - **Go module**: `github.com/aptos-labs/confidential-asset-bindings/bindings/go` (use your fork path with `replace` when needed).
-- **Native FFI static libraries** ship on **GitHub Releases** (not npm). After each successful **npm** publish, [`release.yml`](../.github/workflows/release.yml) pushes git tag **`vX.Y.Z`**, which runs **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** and publishes the staticlibs + `SHA256SUMS` for the same semver as `package.json` (no separate manual tagging in the default flow).
+- **Native FFI static libraries** ship on **GitHub Releases** (not npm). After each successful **npm** publish, [`release.yml`](../.github/workflows/release.yml) calls **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** (`workflow_call`) to append staticlibs + `SHA256SUMS` to the Changesets Release for the same semver as `package.json`. It also pushes git tag **`vX.Y.Z`** for version pins (tag push does **not** start the FFI workflow).
 
 ## Rust layout
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -60,7 +60,7 @@ This creates a Markdown file under `.changeset/`. Commit it alongside your code 
 5. **Review and merge the "Version Packages" PR** when you are ready to publish. CI runs again.
 6. **On merge, `changesets/action` publishes to npm** by running `npm run release`. The package appears on the npm registry under `@aptos-labs/confidential-asset-bindings`.
 7. **When publish succeeds**, Changesets creates the **GitHub Release** for **`vX.Y.Z`** with the usual **`### Patch Changes`** notes (same as before native FFI). `release.yml` pushes the annotated git tag to `origin` if it is not already there (for version pins; **does not** trigger FFI).
-8. The same **`release.yml`** run then calls **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** via **`workflow_call`** (**Native FFI release** job), which builds static libraries and **appends** the FFI appendix plus `.tar.gz` / `.zip` / `SHA256SUMS` to that **same** GitHub Release — only after the Changesets Release step has finished. No second Release page.
+8. The same **`release.yml`** run then calls **[`bindings-release.yml`](../../.github/workflows/bindings-release.yml)** via **`workflow_call`** (**Native FFI release** job), which builds static libraries and **appends** the FFI appendix plus `.tar.gz` / `.zip` / `SHA256SUMS` to that **same** GitHub Release — only after the Changesets Release step has finished. No second Release page.
 
 ## GitHub App bot
 
@@ -110,7 +110,7 @@ After npm publish, **`release.yml` pushes `vX.Y.Z` and invokes Native FFI releas
 2. Confirm the GitHub Release for **`vX.Y.Z`** still shows the Changesets changelog and also lists the expected `.tar.gz` / `.zip` assets and **`SHA256SUMS`**.
 3. Optional: `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on Linux/macOS.
 
-**Manual fallback:** **Actions → Release native FFI binaries** (`workflow_dispatch`) if you need a draft rebuild without re-publishing npm.
+**Manual fallback:** **Actions → Release native FFI binaries** (`workflow_dispatch`) only when a GitHub Release for **`vX.Y.Z`** already exists (create it with Changesets changelog notes first, e.g. `gh release create`). The workflow appends FFI assets; it does not replace Changesets. **Re-running** the workflow duplicates the **Native FFI** section in the Release body — edit manually or avoid duplicate dispatches.
 
 Go consumers download **`libaptos_confidential_asset_ffi`** from that GitHub Release (not npm). See [Native bindings](../bindings.md) for supported triples.
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -89,7 +89,7 @@ After the "Version Packages" PR is merged and the publish step completes:
 
    Verify that `dist/` contains the ESM bundle, CJS bundle, type declarations, and `.wasm` file.
 
-4. **Native FFI:** confirm the **Release native FFI binaries** workflow completed for tag **`vX.Y.Z`**. Open the GitHub Release for that tag: the top should show Changesets changelog text; the bottom should include **Native FFI** notes plus `SHA256SUMS` and platform archives. Optionally run `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on a dev machine.
+4. **Native FFI:** on the same **Release** workflow run, confirm the **Native FFI release** job completed. Open the GitHub Release for **`vX.Y.Z`**: Changesets changelog at the top, **Native FFI** notes and `SHA256SUMS` / platform archives below. Optionally run `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on a dev machine.
 
 ## Pre-publishing checklist
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -59,8 +59,8 @@ This creates a Markdown file under `.changeset/`. Commit it alongside your code 
    - If there are no pending changesets, nothing happens.
 5. **Review and merge the "Version Packages" PR** when you are ready to publish. CI runs again.
 6. **On merge, `changesets/action` publishes to npm** by running `npm run release`. The package appears on the npm registry under `@aptos-labs/confidential-asset-bindings`.
-7. **When publish succeeds**, Changesets creates the **GitHub Release** for **`vX.Y.Z`** with the usual **`### Patch Changes`** notes (same as before native FFI). `release.yml` then pushes the annotated tag to `origin` if it is not already there.
-8. The tag push triggers **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** (**Release native FFI binaries**), which builds static libraries and **appends** the FFI appendix plus `.tar.gz` / `.zip` / `SHA256SUMS` assets to that **same** GitHub Release. No second Release page and no manual tagging for the default path.
+7. **When publish succeeds**, Changesets creates the **GitHub Release** for **`vX.Y.Z`** with the usual **`### Patch Changes`** notes (same as before native FFI). `release.yml` pushes the annotated git tag to `origin` if it is not already there (for version pins; **does not** trigger FFI).
+8. The same **`release.yml`** run then calls **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** via **`workflow_call`** (**Native FFI release** job), which builds static libraries and **appends** the FFI appendix plus `.tar.gz` / `.zip` / `SHA256SUMS` to that **same** GitHub Release — only after the Changesets Release step has finished. No second Release page.
 
 ## GitHub App bot
 
@@ -104,9 +104,9 @@ Before merging a "Version Packages" PR, confirm the following:
 
 ## Post-publish checklist (native FFI)
 
-After npm publish, **`release.yml` pushes `vX.Y.Z` automatically**; you do **not** need to tag by hand for the default path.
+After npm publish, **`release.yml` pushes `vX.Y.Z` and invokes Native FFI release automatically**; you do **not** need to tag by hand for the default path.
 
-1. Wait for **Release native FFI binaries** on the Actions tab (all matrix jobs + aggregate).
+1. On the same **Release** workflow run, wait for the **Native FFI release** job (matrix + aggregate).
 2. Confirm the GitHub Release for **`vX.Y.Z`** still shows the Changesets changelog and also lists the expected `.tar.gz` / `.zip` assets and **`SHA256SUMS`**.
 3. Optional: `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on Linux/macOS.
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -59,9 +59,8 @@ This creates a Markdown file under `.changeset/`. Commit it alongside your code 
    - If there are no pending changesets, nothing happens.
 5. **Review and merge the "Version Packages" PR** when you are ready to publish. CI runs again.
 6. **On merge, `changesets/action` publishes to npm** by running `npm run release`. The package appears on the npm registry under `@aptos-labs/confidential-asset-bindings`.
-7. **When publish succeeds**, `release.yml` pushes annotated git tag **`vX.Y.Z`** (from `package.json`) to `origin`. That tag triggers **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** (**Release native FFI binaries**), which builds static libraries for all matrix targets and creates the **GitHub Release** with archives and `SHA256SUMS`. No separate manual tagging step is required for the normal path.
-
-The Changesets action is configured with **`createGithubReleases: false`** so the **single** GitHub Release for a version is the native-FFI one (npm changelog remains in `CHANGELOG.md` on `main`).
+7. **When publish succeeds**, Changesets creates the **GitHub Release** for **`vX.Y.Z`** with the usual **`### Patch Changes`** notes (same as before native FFI). `release.yml` then pushes the annotated tag to `origin` if it is not already there.
+8. The tag push triggers **[`bindings-release.yml`](../.github/workflows/bindings-release.yml)** (**Release native FFI binaries**), which builds static libraries and **appends** the FFI appendix plus `.tar.gz` / `.zip` / `SHA256SUMS` assets to that **same** GitHub Release. No second Release page and no manual tagging for the default path.
 
 ## GitHub App bot
 
@@ -90,7 +89,7 @@ After the "Version Packages" PR is merged and the publish step completes:
 
    Verify that `dist/` contains the ESM bundle, CJS bundle, type declarations, and `.wasm` file.
 
-4. **Native FFI:** confirm the **Release native FFI binaries** workflow completed for tag **`vX.Y.Z`** (triggered automatically after npm publish). Open the GitHub Release for that tag and verify `SHA256SUMS` and platform archives. Optionally run `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on a dev machine.
+4. **Native FFI:** confirm the **Release native FFI binaries** workflow completed for tag **`vX.Y.Z`**. Open the GitHub Release for that tag: the top should show Changesets changelog text; the bottom should include **Native FFI** notes plus `SHA256SUMS` and platform archives. Optionally run `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on a dev machine.
 
 ## Pre-publishing checklist
 
@@ -108,7 +107,7 @@ Before merging a "Version Packages" PR, confirm the following:
 After npm publish, **`release.yml` pushes `vX.Y.Z` automatically**; you do **not** need to tag by hand for the default path.
 
 1. Wait for **Release native FFI binaries** on the Actions tab (all matrix jobs + aggregate).
-2. Confirm the GitHub Release for **`vX.Y.Z`** lists the expected `.tar.gz` / `.zip` assets and **`SHA256SUMS`**.
+2. Confirm the GitHub Release for **`vX.Y.Z`** still shows the Changesets changelog and also lists the expected `.tar.gz` / `.zip` assets and **`SHA256SUMS`**.
 3. Optional: `./scripts/install-go-ffi-from-release.sh vX.Y.Z` on Linux/macOS.
 
 **Manual fallback:** **Actions → Release native FFI binaries** (`workflow_dispatch`) if you need a draft rebuild without re-publishing npm.


### PR DESCRIPTION
## Summary

Fixes the broken `v1.1.2` release pipeline and restores a **single GitHub Release per version**: Changesets publishes the npm changelog, then **the same `release.yml` run** calls the native FFI workflow to append static libraries — **no tag-push trigger**.

## Problem

After merging **chore: version packages** (#23):

| Expected | Actual |
|----------|--------|
| npm `@aptos-labs/confidential-asset-bindings@1.1.2` | Published |
| Git tag `v1.1.2` on `origin` | **Missing** (tag push bug) |
| GitHub Release with changelog | **Missing** (`createGithubReleases: false` in #22) |
| FFI archives on the Release | **Missing** |

Tag-push triggering also made ordering implicit (webhook could start FFI before the Changesets Release API finished).

## Solution

### `release.yml` (two jobs, one workflow run)

```mermaid
flowchart TD
  A[1. Version PR merge] --> B[2. job: Release]
  B --> C[3. changeset publish]
  C --> D[4. npm + Changesets GitHub Release]
  D --> E[5. Push git tag vX.Y.Z if missing]
  E --> F[6. job: Native FFI release]
  F --> G[7. workflow_call bindings-release.yml]
  G --> H[8. Build FFI matrix]
  H --> I[9. append_body + upload archives]
  D --> J[One GitHub Release page]
  I --> J
```

1. **Restore Changesets GitHub Releases** (remove `createGithubReleases: false`).
2. **Fix tag push** — push local tag from `changeset publish` when missing on `origin` (for git/Go pins only).
3. **`native-ffi-release` job** — `needs: release`, `if: published`, `uses: ./.github/workflows/bindings-release.yml` with `workflow_call` so FFI runs **after** the publish job completes.

### `bindings-release.yml`

- **`on.workflow_call`** — primary path from `release.yml`.
- **Removed `on.push.tags`** — tag push no longer starts a duplicate FFI run.
- **`workflow_dispatch`** — manual backfill / dry-run only.
- **`append_body: true`** — append Native FFI section + assets to the existing Changesets Release.

## Ordering for `v1.1.3`

| Step | Guaranteed order |
|------|------------------|
| Changesets Release created | In `Release` job, before FFI job starts |
| FFI workflow starts | Only when `Release` job finishes (`needs`) |
| FFI attach | After matrix builds, on existing Release |

No webhook race between tag push and Changesets.

## Follow-up (outside this PR)

Backfill **`v1.1.2`** at `fe2b2f0`: push tag and/or **workflow_dispatch** FFI with `version: 1.1.2`.

## Test plan

- [ ] Review workflow diff
- [ ] Next Version Packages publish: one **Release** workflow with **Release** + **Native FFI release** jobs
- [ ] Same GitHub Release: changelog + Native FFI + archives
- [ ] Confirm pushing a tag alone does **not** start **Release native FFI binaries**