### PR TITLE
fix(cgo): remove -L${SRCDIR} from LDFLAGS to eliminate ld warning for external consumers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,7 +49,7 @@ OIDC Trusted Publisher.
 
 CGO files use:
 - `CFLAGS: -I${SRCDIR}/include` — header always present in the repo
-- `LDFLAGS: -L${SRCDIR}/native/<triple> -laptos_confidential_asset_ffi`
+- `LDFLAGS: -laptos_confidential_asset_ffi` — no `-L` path; caller must set `CGO_LDFLAGS`
 
 **In-repo development** — stage the built `.a` manually:
 
@@ -58,7 +58,7 @@ cargo build -p aptos_confidential_asset_ffi --release --manifest-path rust/Cargo
 TRIPLE=aarch64-apple-darwin
 mkdir -p bindings/go/aptosconfidential/native/$TRIPLE
 cp rust/target/release/libaptos_confidential_asset_ffi.a bindings/go/aptosconfidential/native/$TRIPLE/
-cd bindings/go && go test ./aptosconfidential/...
+cd bindings/go && CGO_LDFLAGS="-L$(pwd)/aptosconfidential/native/$TRIPLE" go test ./aptosconfidential/...
 ```
 
 **External consumer** — download prebuilt library, then build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Go bindings (golden + smoke)
         env:
           CGO_ENABLED: "1"
+          CGO_LDFLAGS: "-L${{ github.workspace }}/bindings/go/aptosconfidential/native/x86_64-unknown-linux-gnu"
         run: |
           cd bindings/go
           go test -v ./aptosconfidential/...

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -33,7 +33,8 @@ cp rust/target/release/libaptos_confidential_asset_ffi.a bindings/go/aptosconfid
 # Windows: cp rust\target\release\aptos_confidential_asset_ffi.lib bindings\go\aptosconfidential\native\$TRIPLE\
 
 # 3. Test
-cd bindings/go && go test ./aptosconfidential/...
+cd bindings/go
+CGO_LDFLAGS="-L$(pwd)/aptosconfidential/native/$TRIPLE" go test ./aptosconfidential/...
 ```
 
 For musl Linux, use `-tags musl` and set `TRIPLE=x86_64-unknown-linux-musl` (or `aarch64-unknown-linux-musl`). When running the download tool on a glibc host targeting musl, set `CA_MUSL=1` so it downloads the musl variant (auto-detection only works on musl hosts).

--- a/bindings/go/aptosconfidential/cgo_darwin_amd64.go
+++ b/bindings/go/aptosconfidential/cgo_darwin_amd64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/x86_64-apple-darwin -laptos_confidential_asset_ffi
+#cgo LDFLAGS: -laptos_confidential_asset_ffi
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_darwin_arm64.go
+++ b/bindings/go/aptosconfidential/cgo_darwin_arm64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/aarch64-apple-darwin -laptos_confidential_asset_ffi
+#cgo LDFLAGS: -laptos_confidential_asset_ffi
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_linux_amd64.go
+++ b/bindings/go/aptosconfidential/cgo_linux_amd64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/x86_64-unknown-linux-gnu -laptos_confidential_asset_ffi -ldl -lpthread -lm
+#cgo LDFLAGS: -laptos_confidential_asset_ffi -ldl -lpthread -lm
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_linux_amd64_musl.go
+++ b/bindings/go/aptosconfidential/cgo_linux_amd64_musl.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/x86_64-unknown-linux-musl -laptos_confidential_asset_ffi -static -lpthread -ldl -lm
+#cgo LDFLAGS: -laptos_confidential_asset_ffi -static -lpthread -ldl -lm
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_linux_arm64.go
+++ b/bindings/go/aptosconfidential/cgo_linux_arm64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/aarch64-unknown-linux-gnu -laptos_confidential_asset_ffi -ldl -lpthread -lm
+#cgo LDFLAGS: -laptos_confidential_asset_ffi -ldl -lpthread -lm
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_linux_arm64_musl.go
+++ b/bindings/go/aptosconfidential/cgo_linux_arm64_musl.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/aarch64-unknown-linux-musl -laptos_confidential_asset_ffi -lpthread -ldl -lm
+#cgo LDFLAGS: -laptos_confidential_asset_ffi -lpthread -ldl -lm
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_windows_amd64.go
+++ b/bindings/go/aptosconfidential/cgo_windows_amd64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/x86_64-pc-windows-msvc -l:aptos_confidential_asset_ffi.lib
+#cgo LDFLAGS: -l:aptos_confidential_asset_ffi.lib
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */

--- a/bindings/go/aptosconfidential/cgo_windows_arm64.go
+++ b/bindings/go/aptosconfidential/cgo_windows_arm64.go
@@ -4,7 +4,7 @@ package aptosconfidential
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
-#cgo LDFLAGS: -L${SRCDIR}/native/aarch64-pc-windows-msvc -l:aptos_confidential_asset_ffi.lib
+#cgo LDFLAGS: -l:aptos_confidential_asset_ffi.lib
 #include "aptos_confidential_asset.h"
 #include <stdlib.h>
 */


### PR DESCRIPTION
## Summary

- Remove `-L${SRCDIR}/native/<triple>` from all 8 platform CGO files — this path only resolved correctly for in-repo builds. External consumers saw a spurious `ld: warning: search path '...go@v1.1.2/aptosconfidential/native/<triple>' not found` because `${SRCDIR}` expands to the read-only module cache where no `.a` file exists.
- Both in-repo developers and external consumers now pass the library search path explicitly via `CGO_LDFLAGS`.
- CI, README, and CLAUDE.md updated to reflect the new requirement.

## Usage after this change

**External consumer:**
```bash
go run github.com/aptos-labs/confidential-asset-bindings/bindings/go/aptosconfidential/tools/download@v1.1.3
CGO_LDFLAGS="-L$(pwd)/native/aarch64-apple-darwin" go build ./...
```

**In-repo developer:**
```bash
cargo build -p aptos_confidential_asset_ffi --release --manifest-path rust/Cargo.toml
TRIPLE=aarch64-apple-darwin
mkdir -p bindings/go/aptosconfidential/native/$TRIPLE
cp rust/target/release/libaptos_confidential_asset_ffi.a bindings/go/aptosconfidential/native/$TRIPLE/
cd bindings/go
CGO_LDFLAGS="-L$(pwd)/aptosconfidential/native/$TRIPLE" go test ./aptosconfidential/...
```

## Test plan

- [x] In-repo: `CGO_LDFLAGS="-L$(pwd)/aptosconfidential/native/aarch64-apple-darwin" go test ./aptosconfidential/...` — PASS, zero ld warnings
- [x] External consumer (via local replace): `CGO_LDFLAGS="-L$(pwd)/native/aarch64-apple-darwin" go build ./...` — PASS, zero ld warnings
- [ ] CI `go-bindings-smoke` (linux/amd64) passes with updated `CGO_LDFLAGS` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)